### PR TITLE
In order to use ProSoul with web dashboards elasticsearch must be accesible

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,8 +113,8 @@ services:
             - default
         expose:
             - 9200
-#        ports:
-#          - "9200:9200"
+        ports:
+            - "9200:9200"
         environment:
           - ES_JAVA_OPTS=-Xms2g -Xmx2g
           - ES_TMPDIR=/tmp


### PR DESCRIPTION
The port 9200 in which elasticsearch listen is opened to the host.