### PR TITLE
Deploy GrimoireLab global package and use a specific version, fix ports opened and dependencies

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -10,6 +10,8 @@
 
 FROM python
 
+ENV GRIMOIRELAB_RELEASE "0.1.2"
+
 RUN apt-get update \
 &&  apt-get install -y git \
 subversion \
@@ -27,8 +29,7 @@ RUN pip3 install --upgrade pip \
 setuptools \
 wheel
 
-RUN pip3 install grimoire-elk \
-kidash
+RUN pip3 install grimoirelab==${GRIMOIRELAB_RELEASE}
 
 # Downloads perceval-scava and scava metrics folders from Github in 'dev' branch
 RUN svn export https://github.com/crossminer/scava/branches/dev/web-dashboards/perceval-scava \

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -25,11 +25,14 @@ build-essential
 #py3-scipy
 
 # Install GrimoireLab
-RUN pip3 install --upgrade pip \
-setuptools \
-wheel
+RUN pip3 install --upgrade pip setuptools wheel
 
 RUN pip3 install grimoirelab==${GRIMOIRELAB_RELEASE}
+
+# Install kidash from master
+RUN git clone https://github.com/chaoss/grimoirelab-kidash.git && \
+    cd grimoirelab-kidash && \
+    pip3 install .
 
 # Downloads perceval-scava and scava metrics folders from Github in 'dev' branch
 RUN svn export https://github.com/crossminer/scava/branches/dev/web-dashboards/perceval-scava \

--- a/dashboard/importer.sh
+++ b/dashboard/importer.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
+# Import all the Scava metrics to Elasticsearch to be used in Kibana
 cd scava-metrics
 ./scava2es.py -g -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-metrics
 
-kidash -e https://admin:admin@elasticsearch:9200 --import panels/scava-project.json
+# Import the panels with the dashboards to show the Scava metrics imported above
+kidash -e https://admin:admin@elasticsearch:9200 --kibana-url http://admin:admin@kibiter:5601 --import panels/scava-project.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,8 +113,8 @@ services:
             - default
         expose:
             - 9200
-#        ports:
-#          - "9200:9200"
+        ports:
+          - "9200:9200"
         environment:
           - ES_JAVA_OPTS=-Xms2g -Xmx2g
           - ES_TMPDIR=/tmp
@@ -136,5 +136,6 @@ services:
         depends_on:
             - oss-app
             - elasticsearch
+            - kibiter
         networks:
             - default


### PR DESCRIPTION
In order CROSSMINER continues working no matter GrimoireLab changes,
a fixed version will be installed in which the perceval backend and the
metrics imported work.

Also, until a fix for kidash needed for the bootstrap of Kibana is included in a grimoirelab release,
we need to install it from master.

Apart from data, added to the importer the kibiter dependency so it can load the panels, and opened the Elasticsearch port so ProSoul can access it.