### PR TITLE
[dashboard] Update Grimoirelab tools versions

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -10,7 +10,8 @@
 
 FROM python
 
-ENV GRIMOIRELAB_RELEASE "0.1.2"
+ENV GRIMOIRELAB_RELEASE "0.1.4"
+ENV KIDASH_RELEASE "0.4.12"
 
 RUN apt-get update \
 &&  apt-get install -y git \
@@ -29,10 +30,7 @@ RUN pip3 install --upgrade pip setuptools wheel
 
 RUN pip3 install grimoirelab==${GRIMOIRELAB_RELEASE}
 
-# Install kidash from master
-RUN git clone https://github.com/chaoss/grimoirelab-kidash.git && \
-    cd grimoirelab-kidash && \
-    pip3 install .
+RUN pip3 install kidash==${KIDASH_RELEASE}
 
 # Downloads perceval-scava and scava metrics folders from Github in 'dev' branch
 RUN svn export https://github.com/crossminer/scava/branches/dev/web-dashboards/perceval-scava \

--- a/dashboard/starter.sh
+++ b/dashboard/starter.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 while true;
+sleep 10;
 do ./importer.sh;
 #wait 5 minutes
 sleep 300;

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -190,3 +190,5 @@ services:
         depends_on:
          - kibiter
          - elasticsearch
+        environment:
+         - ALLOWED_HOSTS=prosoul localhost 127.0.01


### PR DESCRIPTION
This PR addresses some minor issues. Please, read them below.

First, the docker-compose-build of scava-deployment has been modified to include the `ALLOWED_HOSTS` variable in the environment. This allows to pass the list of allowed hosts to Prosoul without the need of modifying the code. 

Second, the versions of GrimoireLab and Kidash used in CROSSMINER have been updated (respectively to 0.1.4 and 0.4.12) to target the issue reported by @mhow2:
```
grimoirelab 0.1.2 has requirement kidash==0.4.9, but you'll have kidash 0.4.13 
which is incompatible.` . It is the result of the step at that line in the Dockerfile 
https://github.com/crossminer/scava-deployment/blob/87daeb923e08d35f975ba281c9be9f973d4180da/dashboard/Dockerfile#L33
```
Third, a waiting time has been added to [starter.sh](https://github.com/crossminer/scava-deployment/blob/dashboard-plus-admin/dashboard/starter.sh), in charge of importing the data to ElasticSearch. This change was needed to give the time to ElasticSearch and Kibana to start, thus avoiding 503 HTTP errors (which anyway were not affecting the transfer of data).