### PR TITLE
[dashboards] Upload sentiment and dependencies dashboards

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -34,7 +34,9 @@ RUN pip3 install kidash==${KIDASH_RELEASE}
 
 # Downloads perceval-scava and scava metrics folders from Github in 'dev' branch
 RUN svn export https://github.com/crossminer/scava/branches/dev/web-dashboards/perceval-scava \
-&& svn export https://github.com/crossminer/scava/branches/dev/web-dashboards/scava-metrics
+&& svn export https://github.com/crossminer/scava/branches/dev/web-dashboards/scava-metrics \
+&& svn export https://github.com/crossminer/scava/branches/dev/web-dashboards/sentiment \
+&& svn export https://github.com/crossminer/scava/branches/dev/web-dashboards/dependencies
 
 # Install perceval-scava
 WORKDIR perceval-scava
@@ -42,12 +44,14 @@ RUN pip3 install .
 
 WORKDIR ..
 
-COPY importer.sh importer.sh
+COPY importer-dashboards.sh importer-dashboards.sh
+COPY importer-scava-metrics.sh importer-scava-metrics.sh
 COPY starter.sh starter.sh
 COPY wait-for-it.sh wait-for-it.sh
 
 RUN chmod +x wait-for-it.sh
-RUN chmod +x importer.sh
+RUN chmod +x importer-dashboards.sh
+RUN chmod +x importer-scava-metrics.sh
 RUN chmod +x starter.sh
 
 ENTRYPOINT ["/starter.sh"]

--- a/dashboard/importer-dashboards.sh
+++ b/dashboard/importer-dashboards.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+cd scava-metrics
+# Import knowledge base dashboards
+kidash -e https://admin:admin@elasticsearch:9200 --kibana-url http://admin:admin@kibiter:80 --import panels/scava-project.json
+
+cd ../sentiment
+# Import sentiment dashboards
+kidash -e https://admin:admin@elasticsearch:9200 --kibana-url http://admin:admin@kibiter:80 --import panels/perceval_bugs_emotion_fear.json
+kidash -e https://admin:admin@elasticsearch:9200 --kibana-url http://admin:admin@kibiter:80 --import panels/perceval_bugs_emotions.json
+
+cd ../dependencies
+# Import dependencies dashboards
+kidash -e https://admin:admin@elasticsearch:9200 --kibana-url http://admin:admin@kibiter:80 --import panels/dependencies.json

--- a/dashboard/importer-scava-metrics.sh
+++ b/dashboard/importer-scava-metrics.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# Import all the Scava metrics to Elasticsearch to be used in Kibana
+cd scava-metrics
+./scava2es.py -g -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-metrics

--- a/dashboard/importer.sh
+++ b/dashboard/importer.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-# Import all the Scava metrics to Elasticsearch to be used in Kibana
-cd scava-metrics
-./scava2es.py -g -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-metrics
-
-# Import the panels with the dashboards to show the Scava metrics imported above
-kidash -e https://admin:admin@elasticsearch:9200 --kibana-url http://admin:admin@kibiter:5601 --import panels/scava-project.json

--- a/dashboard/starter.sh
+++ b/dashboard/starter.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
-while true;
-sleep 10;
-do ./importer.sh;
-#wait 5 minutes
-sleep 300;
+while true; do
+    ./importer-scava-metrics.sh;
+    ./importer-dashboards.sh;
+    sleep 300;
 done

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -63,7 +63,6 @@ services:
         ports:
           - "8182:8182"
 
-
 #     oss-slave: # Service containing OSSMETER slaves instances
 #         build: ./metric-platform
 #         entrypoint: ./eclipse -worker w1  -ossmeterConfig prop.properties
@@ -176,7 +175,10 @@ services:
 
     dashb-importer:
         build: ./dashboard
-        entrypoint: ["./wait-for-it.sh", "oss-app:8182", "-t", "0", "--", "./wait-for-it.sh", "elasticsearch:9200", "-t", "0", "--", "./starter.sh"]
+        entrypoint: ["./wait-for-it.sh", "oss-app:8182", "-t", "0", "--",
+                     "./wait-for-it.sh", "elasticsearch:9200", "-t", "0", "--",
+                     "./wait-for-it.sh", "kibiter:80", "-t", "0", "--",
+                     "./starter.sh"]
         depends_on:
             - oss-app
             - elasticsearch
@@ -192,4 +194,4 @@ services:
          - kibiter
          - elasticsearch
         environment:
-         - ALLOWED_HOSTS=prosoul localhost 127.0.01
+         - ALLOWED_HOSTS=prosoul localhost 127.0.0.1


### PR DESCRIPTION
This PR allows to upload the sentiment and dependencies dashboards (defined in a previous deliverable), which currently are not tested. Furtheremore it updates the kibiter port in the importer script (a change needed due to the port swaping between the `kibiter` and `admin-webapp` images.