### PR TITLE
Retrieve API Gateway & Auth Service JARs directly from CI builds

### DIFF
--- a/api-gw/Dockerfile
+++ b/api-gw/Dockerfile
@@ -4,7 +4,7 @@ FROM openjdk:8-jre-alpine
 LABEL description="Image with the API Gateway"
 
 # Downloads last jar build  by the continuous integration server
-RUN wget http://ci3.castalia.camp/dl/scava-api-gateway-1.0.0.jar
+RUN wget http://ci5.castalia.camp:8080/job/scava-api-gateway/job/dev/lastSuccessfulBuild/artifact/api-gateway/org.eclipse.scava.apigateway/target/scava-api-gateway-1.0.0.jar
 
 COPY application.properties application.properties
 

--- a/auth/Dockerfile
+++ b/auth/Dockerfile
@@ -6,7 +6,7 @@ LABEL description="Image with the Authentication Server"
 RUN apk add --no-cache bash
 
 # Downloads last jar build  by the continuous integration server
-RUN wget http://ci3.castalia.camp/dl/scava-auth-service-1.0.0.jar
+RUN wget http://ci5.castalia.camp:8080/job/scava-auth-service/job/dev/lastSuccessfulBuild/artifact/api-gateway/org.eclipse.scava.authservice/target/scava-auth-service-1.0.0.jar
 
 
 COPY application.properties application.properties


### PR DESCRIPTION
I've updated the [scava-api-gateway](http://ci5.castalia.camp:8080/job/scava-api-gateway/) job on Jenkins to archive the JAR of the last successful build from `dev` and created a new similar job for the authentication service: [scava-auth-service](http://ci5.castalia.camp:8080/job/scava-auth-service).

So now we can retrieve `scava-api-gateway-1.0.0.jar` and `scava-auth-service-1.0.0.jar` directly from the Jenkins build without having to store them on `ci3`.
