### PR TITLE
[dashboard] Import factoids to ElasticSearch dashboard

### DIFF
--- a/dashboard/importer-scava-metrics.sh
+++ b/dashboard/importer-scava-metrics.sh
@@ -4,7 +4,9 @@
 cd scava-metrics
 
 if [[ $DASHDEBUG -eq 1 ]]; then
-    ./scava2es.py -g -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-metrics;
+    ./scava2es.py -g -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-metrics --category metric;
+    ./scava2es.py -g -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-factoids --category factoid;
 else
-    ./scava2es.py -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-metrics;
+    ./scava2es.py -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-metrics --category metric;
+    ./scava2es.py -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-factoids --category factoid;
 fi


### PR DESCRIPTION
This PR modifies the script to fetch factoids data of projects. Such a data is stored in the new index `scava-factoids`.