### PR TITLE
[dashboard] Allow to import custom quality model

### DIFF
--- a/dashboard/starter.sh
+++ b/dashboard/starter.sh
@@ -6,6 +6,7 @@ while true; do
 
     if [[ $FLAG -eq 0 ]]; then
         ./importer-dashboards.sh;
+        curl -XPUT https://admin:admin@elasticsearch:9200/scava-metrics-done --insecure
         FLAG=1;
     fi
     sleep 300;

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -193,7 +193,7 @@ services:
             - DASHDEBUG=0
 
     prosoul:
-        image: bitergia/prosoul
+        build: ./quality-model
         ports:
          - "8000:8000"
         depends_on:
@@ -203,3 +203,6 @@ services:
          - ALLOWED_HOSTS=prosoul localhost 127.0.0.1
          - ES_URL=https://admin:admin@elasticsearch:9200
          - KIBITER_URL=https://kibiter:80
+         - DASHDEBUG=0
+         - QM_URL=https://raw.githubusercontent.com/Bitergia/prosoul/master/django-prosoul/prosoul/data/qmodel_crossminer.json
+         - QM_NAME=crossminer

--- a/quality-model/Dockerfile
+++ b/quality-model/Dockerfile
@@ -1,0 +1,57 @@
+# Copyright (C) 2018 Bitergia
+# GPLv3 License
+
+FROM debian:stretch-slim
+MAINTAINER Alvaro del Castillo <acs@bitergia.com>
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV DEPLOY_USER prosoul
+ENV DEPLOY_USER_DIR /home/${DEPLOY_USER}
+
+# Initial user
+RUN useradd ${DEPLOY_USER} --create-home --shell /bin/bash
+
+# install dependencies
+RUN apt-get update && \
+    apt-get -y install --no-install-recommends \
+        bash locales \
+        gcc \
+        git git-core \
+        python3 \
+        python3-pip \
+        python3-venv \
+        python3-dev python3-tk \
+        unzip curl wget sudo ssh vim \
+        && \
+    apt-get clean && \
+    find /var/lib/apt/lists -type f -delete
+
+RUN echo "${DEPLOY_USER} ALL=NOPASSWD: ALL" >> /etc/sudoers
+
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    echo 'LANG="en_US.UTF-8"'>/etc/default/locale && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+ENV LANG C.UTF-8
+
+# Install pip packages needed
+RUN pip3 install setuptools
+RUN pip3 install django
+RUN pip3 install gunicorn
+RUN pip3 install matplotlib
+RUN pip3 install requests
+RUN pip3 install kidash
+RUN pip3 install djangorestframework
+
+ADD stage ${DEPLOY_USER_DIR}/stage
+RUN chmod 755 ${DEPLOY_USER_DIR}/stage
+
+USER ${DEPLOY_USER}
+
+WORKDIR ${DEPLOY_USER_DIR}
+
+CMD ${DEPLOY_USER_DIR}/stage

--- a/quality-model/stage
+++ b/quality-model/stage
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+echo "Running Prosoul"
+REPOSRC=https://github.com/Bitergia/prosoul.git
+LOCALREPO=prosoul/django-prosoul/
+
+if [ ! -d $LOCALREPO ]
+then
+    git clone $REPOSRC
+fi
+
+cd $LOCALREPO
+
+# Set exec permission for config_deployment.py
+sudo chmod 770 config_deployment.py
+
+# debug false and allow hosts
+./config_deployment.py
+
+# Create the data models
+python3 manage.py makemigrations
+python3 manage.py migrate
+
+# Create the initial admin user: admin/admin
+PYTHONPATH=. django_prosoul/create_admin_superuser.py
+
+# Import some quality models as samples
+PYTHONPATH=. prosoul/prosoul_import.py -f prosoul/data/ossmeter_qm.json --format ossmeter
+PYTHONPATH=. prosoul/prosoul_import.py -f prosoul/data/alambic_quality_model.json --format alambic
+PYTHONPATH=. prosoul/prosoul_import.py -f prosoul/data/basic_maturiy_model.json --format grimoirelab
+# PYTHONPATH=. prosoul/prosoul_import.py -f prosoul/data/qmodel_crossminer.json
+
+# Upload default quality model
+URL=$ES_URL/scava-metrics-done
+
+# check that the scava metrics index exists
+while true; do
+    HTTP_RESPONSE=$(curl --silent --write-out "HTTPSTATUS:%{http_code}" -XGET $URL --insecure)
+    HTTP_STATUS=$(echo $HTTP_RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
+
+    if [ $HTTP_STATUS -eq 200 ]; then
+        break
+    fi
+
+    echo "$URL not available, waiting..."
+    sleep 30;
+done
+
+# Import default_quality_model.json
+wget $QM_URL -O ${DEPLOY_USER_DIR}/default_quality_model.json
+
+if [ $DASHDEBUG -eq 1 ]; then
+     PYTHONPATH=. prosoul/prosoul_import.py -g -f /home/prosoul/default_quality_model.json;
+     PYTHONPATH=. prosoul/prosoul_assess.py -g -e $ES_URL -i scava-metrics -m $QM_NAME -b scava-metrics;
+else
+     PYTHONPATH=. prosoul/prosoul_import.py -f /home/prosoul/default_quality_model.json;
+     PYTHONPATH=. prosoul/prosoul_assess.py -e $ES_URL -i scava-metrics -m $QM_NAME -b scava-metrics;
+fi
+
+# Run the Prosoul service
+python3 manage.py runserver 0.0.0.0:8000
+# There is an issue with gunicorn finding static contents
+# gunicorn django_prosoul.wsgi --bind 0.0.0.0:8000


### PR DESCRIPTION
This PR allows to load and assess a given quality model over the projects contained in SCAVA. In a nutshell, after importing the metrics to ElasticSearch, the index `scava-metrics-done` is created via the `dashb-importer` container. This index is needed to notify the `prosoul` container, which can then trigger the import and assessment of a default quality model. The quality model params are declared in the prosoul section of the docker-compose, they are:
- `QM_NAME`: name of the quality model
- `QM_URL`: url where to download the quality model