### PR TITLE
Update dashboard and quality-model dockerfiles

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -27,9 +27,8 @@ build-essential
 
 # Install GrimoireLab
 RUN pip3 install --upgrade pip setuptools wheel
-
+RUN pip3 install requests
 RUN pip3 install grimoirelab==${GRIMOIRELAB_RELEASE}
-
 RUN pip3 install kidash==${KIDASH_RELEASE}
 
 # Downloads perceval-scava and scava metrics folders from Github in 'dev' branch

--- a/quality-model/Dockerfile
+++ b/quality-model/Dockerfile
@@ -39,7 +39,7 @@ ENV LC_ALL en_US.UTF-8
 ENV LANG C.UTF-8
 
 # Install pip packages needed
-RUN pip3 install setuptools
+RUN pip3 install --upgrade pip setuptools wheel
 RUN pip3 install django
 RUN pip3 install gunicorn
 RUN pip3 install matplotlib


### PR DESCRIPTION
This PR allows to fix errors (reported by @mhow2 ) which appeared when building the docker-compose, notably:
```
`Collecting more-itertools (from jaraco.functools>=1.20->tempora>=1.8->portend>=2.1.1->cherrypy<=11.0.0,>=8.1->kingarthur>=0.1.1->grimoire-elk>=0.30.18->kidash)`
  `Downloading https://files.pythonhosted.org/packages/b3/73/64fb5922b745fc1daee8a2880d907d2a70d9c7bb71eea86fcb9445daab5e/more_itertools-7.0.0-py3-none-any.whl (53kB)`
`Building wheels for collected packages: pyyaml, sqlalchemy, feedparser, dulwich`
  `Running setup.py bdist_wheel for pyyaml: started`
  `Running setup.py bdist_wheel for pyyaml: finished with status 'error'`
  `Complete output from command /usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-h874i3l7/pyyaml/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmp70280dx8pip-wheel- --python-tag cp35:`
  `usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]`
     `or: -c --help [cmd1 cmd2 ...]`
     `or: -c --help-commands`
     `or: -c cmd --help`

  `error: invalid command 'bdist_wheel'`

  `----------------------------------------`
  `Failed building wheel for pyyaml`
  `Running setup.py clean for pyyaml`
```
and 
```
ERROR: requests 2.21.0 has requirement urllib3<1.25,>=1.21.1, but you'll have urllib3 1.25.2 which is incompatible.
```

Please @mhow2 would you mind review this PR (thanks) ?