### PR TITLE
[dashboard] Import dependency data and dashboard

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -33,9 +33,7 @@ RUN pip3 install kidash==${KIDASH_RELEASE}
 
 # Downloads perceval-scava and scava metrics folders from Github in 'dev' branch
 RUN svn export https://github.com/crossminer/scava/branches/dev/web-dashboards/perceval-scava \
-&& svn export https://github.com/crossminer/scava/branches/dev/web-dashboards/scava-metrics \
-&& svn export https://github.com/crossminer/scava/branches/dev/web-dashboards/sentiment \
-&& svn export https://github.com/crossminer/scava/branches/dev/web-dashboards/dependencies
+&& svn export https://github.com/crossminer/scava/branches/dev/web-dashboards/scava-metrics
 
 # Install perceval-scava
 WORKDIR perceval-scava

--- a/dashboard/importer-dashboards.sh
+++ b/dashboard/importer-dashboards.sh
@@ -1,25 +1,18 @@
 #!/usr/bin/env bash
 
 cd scava-metrics
-# Import knowledge base dashboards (legacy)
+# Import knowledge base dashboard (legacy)
 kidash -e https://admin:admin@elasticsearch:9200 --kibana-url http://admin:admin@kibiter:5601 --import panels/scava-project.json
-# Import sentiment base dashboards
+# Import sentiment dashboard
 kidash -e https://admin:admin@elasticsearch:9200 --kibana-url http://admin:admin@kibiter:5601 --import panels/scava-sentiment.json
-# Import sentiment base dashboards
+# Import factoid dashboard
 kidash -e https://admin:admin@elasticsearch:9200 --kibana-url http://admin:admin@kibiter:5601 --import panels/scava-factoids.json
-# Import QM base dashboards
+# Import QM base dashboard
 kidash -e https://admin:admin@elasticsearch:9200 --kibana-url http://admin:admin@kibiter:5601 --import panels/scava-qm.json
-# Import QM base dashboards
+# Import overview dashboard
 kidash -e https://admin:admin@elasticsearch:9200 --kibana-url http://admin:admin@kibiter:5601 --import panels/scava-dashboard.json
-
-# cd ../sentiment
-# Import sentiment dashboards
-# kidash -e https://admin:admin@elasticsearch:9200 --kibana-url http://admin:admin@kibiter:5601 --import panels/perceval_bugs_emotion_fear.json
-# kidash -e https://admin:admin@elasticsearch:9200 --kibana-url http://admin:admin@kibiter:5601 --import panels/perceval_bugs_emotions.json
-
-# cd ../dependencies
-# Import dependencies dashboards
-# kidash -e https://admin:admin@elasticsearch:9200 --kibana-url http://admin:admin@kibiter:5601 --import panels/dependencies.json
+# Import dependency dashboard
+kidash -e https://admin:admin@elasticsearch:9200 --kibana-url http://admin:admin@kibiter:5601 --import panels/scava-dependencies.json
 
 sleep 10;
 

--- a/dashboard/importer-scava-metrics.sh
+++ b/dashboard/importer-scava-metrics.sh
@@ -6,7 +6,9 @@ cd scava-metrics
 if [[ $DASHDEBUG -eq 1 ]]; then
     ./scava2es.py -g -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-metrics --category metric;
     ./scava2es.py -g -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-factoids --category factoid;
+    ./scava2es.py -g -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-deps --category dependency;
 else
     ./scava2es.py -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-metrics --category metric;
     ./scava2es.py -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-factoids --category factoid;
+    ./scava2es.py -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-deps --category dependency;
 fi


### PR DESCRIPTION
This PR modifies the importer-dashboards.sh in order to upload the dependency dashboard. Furthermore, it also modifies the importer-scava-metrics.sh to extract the dependency data from the raw endpoint of the SCAVA API, process and finally store it to elasticsearch.