### PR TITLE
[dashboard] Allow optional sync between Scava and ES

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -52,5 +52,6 @@ RUN chmod +x importer-scava-metrics.sh
 RUN chmod +x starter.sh
 RUN chmod +x scava-metrics/scava2es.py
 RUN chmod +x scava-metrics/setindexpattern.py
+RUN chmod +x scava-metrics/synccontent.py
 
 ENTRYPOINT ["/starter.sh"]

--- a/dashboard/importer-scava-metrics.sh
+++ b/dashboard/importer-scava-metrics.sh
@@ -12,3 +12,7 @@ else
     ./scava2es.py -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-factoids --category factoid;
     ./scava2es.py -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-deps --category dependency;
 fi
+
+if [[ $SYNC_ES_SCAVA -eq 1]]; then
+    ./synccontent.py -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-metrics scava-factoids scava-deps;
+fi

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -204,5 +204,6 @@ services:
          - ES_URL=https://admin:admin@elasticsearch:9200
          - KIBITER_URL=https://kibiter:80
          - DASHDEBUG=0
+         - SYNC_ES_SCAVA=0
          - QM_URL=https://raw.githubusercontent.com/Bitergia/prosoul/master/django-prosoul/prosoul/data/qmodel_crossminer.json
          - QM_NAME=crossminer


### PR DESCRIPTION
This code allows to sync the Scava and ES content using a script that checks that the projects stored in ES are also available through the SCAVA API. In case of mismatch, the projects and their data are deleted from ES.