### PR TITLE
Add new env variable in order to define the host where Kibiter is deloyed

### DIFF
--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -203,6 +203,7 @@ services:
          - ALLOWED_HOSTS=prosoul localhost 127.0.0.1
          - ES_URL=https://admin:admin@elasticsearch:9200
          - KIBITER_URL=https://kibiter:80
+         - KIBITER_HOST=http://localhost:80
          - DASHDEBUG=0
          - QM_URL=https://raw.githubusercontent.com/Bitergia/prosoul/master/django-prosoul/prosoul/data/qmodel_crossminer.json
          - QM_NAME=crossminer


### PR DESCRIPTION
In order to fix redirection problems when clicking on Prosoul links (the ones that redirect you to Kibiter), this new env variable must be added, defining the host where Kibiter is deployed.

Therefore, this URL must be accessible outside the containers. By default, it is defined as `http://localhost:80`

