### PR TITLE
[dashboard] Make bulk-size tunable from docker-compose

### DIFF
--- a/dashboard/importer-scava-metrics.sh
+++ b/dashboard/importer-scava-metrics.sh
@@ -4,17 +4,17 @@
 cd scava-metrics
 
 if [[ $DASHDEBUG -eq 1 ]]; then
-    ./scava2es.py -g -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-metrics --category metric --bulk-size 500;
-    ./scava2es.py -g -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-factoids --category factoid --bulk-size 500;
-    ./scava2es.py -g -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-dev-deps --category dev-dependency --bulk-size 500;
-    ./scava2es.py -g -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-conf-deps --category conf-dependency --bulk-size 500;
-    ./scava2es.py -g -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-users --category user --bulk-size 500;
+    ./scava2es.py -g -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-metrics --category metric --bulk-size $BULKSIZE;
+    ./scava2es.py -g -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-factoids --category factoid --bulk-size $BULKSIZE;
+    ./scava2es.py -g -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-dev-deps --category dev-dependency --bulk-size $BULKSIZE;
+    ./scava2es.py -g -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-conf-deps --category conf-dependency --bulk-size $BULKSIZE;
+    ./scava2es.py -g -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-users --category user --bulk-size $BULKSIZE;
 else
-    ./scava2es.py -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-metrics --category metric --bulk-size 500;
-    ./scava2es.py -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-factoids --category factoid --bulk-size 500;
-    ./scava2es.py -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-dev-deps --category dev-dependency --bulk-size 500;
-    ./scava2es.py -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-conf-deps --category conf-dependency --bulk-size 500;
-    ./scava2es.py -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-users --category user --bulk-size 500;
+    ./scava2es.py -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-metrics --category metric --bulk-size $BULKSIZE;
+    ./scava2es.py -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-factoids --category factoid --bulk-size $BULKSIZE;
+    ./scava2es.py -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-dev-deps --category dev-dependency --bulk-size $BULKSIZE;
+    ./scava2es.py -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-conf-deps --category conf-dependency --bulk-size $BULKSIZE;
+    ./scava2es.py -u http://oss-app:8182 -e https://admin:admin@elasticsearch:9200 -i scava-users --category user --bulk-size $BULKSIZE;
 fi
 
 if [[ $SYNC_ES_SCAVA -eq 1 ]]; then

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -174,6 +174,7 @@ services:
             - default
         environment:
             - DASHDEBUG=0
+            - BULKSIZE=500
 
     prosoul:
         build: ./quality-model


### PR DESCRIPTION
This code allows to set the bulk-size value via the docker-compose, thus preventing possible failures when importing data from scava to ElasticSearch.