### PR TITLE
[docker-compose-build] Set max_content_length for elasticsearch

### DIFF
--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -136,7 +136,7 @@ services:
 
     elasticsearch:
         image: acsdocker/elasticsearch:6.3.1-secured
-        command: /elasticsearch/bin/elasticsearch -E network.bind_host=0.0.0.0
+        command: /elasticsearch/bin/elasticsearch -E network.bind_host=0.0.0.0 -Ehttp.max_content_length=500mb
         networks:
             - default
         expose:


### PR DESCRIPTION
This code sets the max_content_lenght to 500mb for the elasticsearch container.