### PR TITLE
[dashboard] Add devops dependencies dashboard

### DIFF
--- a/dashboard/importer-dashboards.sh
+++ b/dashboard/importer-dashboards.sh
@@ -13,6 +13,8 @@ kidash -e https://admin:admin@elasticsearch:9200 --kibana-url http://admin:admin
 kidash -e https://admin:admin@elasticsearch:9200 --kibana-url http://admin:admin@kibiter:5601 --import panels/scava-overview.json
 # Import dependency dashboard
 kidash -e https://admin:admin@elasticsearch:9200 --kibana-url http://admin:admin@kibiter:5601 --import panels/scava-dependencies.json
+# Import devops dependency dashboard
+kidash -e https://admin:admin@elasticsearch:9200 --kibana-url http://admin:admin@kibiter:5601 --import panels/scava-dependencies-devops.json
 # Import user dashboard
 kidash -e https://admin:admin@elasticsearch:9200 --kibana-url http://admin:admin@kibiter:5601 --import panels/scava-users.json
 


### PR DESCRIPTION
This code allows to upload the devops dependencies dashboard when executing the importer-dashboard script.