### PR TITLE
[dashboard] Allow load sonarqube projects and mappings from URL

### DIFF
--- a/dashboard/importer-sonar-metrics.sh
+++ b/dashboard/importer-sonar-metrics.sh
@@ -4,7 +4,7 @@
 cd scava-metrics
 
 if [[ $DASHDEBUG -eq 1 ]]; then
-    ./sonarqube2es.py -g -u https://sonarqube.ow2.org -e https://admin:admin@elasticsearch:9200 -i scava-metrics --bulk-size $BULKSIZE --components ASM:asm clif-legacy --metrics blocker_violations critical_violations coverage test_success_density;
+    ./sonarqube2es.py -g -u https://sonarqube.ow2.org -e https://admin:admin@elasticsearch:9200 -i scava-metrics --bulk-size $BULKSIZE --metrics blocker_violations critical_violations coverage test_success_density --components https://ow2-utils.ow2.org/cmr/sonar2scava-project-mapping-ow2.json;
 else
-    ./sonarqube2es.py -u https://sonarqube.ow2.org -e https://admin:admin@elasticsearch:9200 -i scava-metrics --bulk-size $BULKSIZE --components ASM:asm clif-legacy --metrics blocker_violations critical_violations coverage test_success_density;
+    ./sonarqube2es.py -u https://sonarqube.ow2.org -e https://admin:admin@elasticsearch:9200 -i scava-metrics --bulk-size $BULKSIZE--metrics blocker_violations critical_violations coverage test_success_density --components https://ow2-utils.ow2.org/cmr/sonar2scava-project-mapping-ow2.json;
 fi


### PR DESCRIPTION
This code allows to pass the sonarqube projects and mappings via a URL. An example is provided below:

./sonarqube2es.py -g
    -u https://sonarqube.ow2.org
    -e https://admin:admin@elasticsearch:9200
    -i scava-metrics
    --bulk-size $BULKSIZE
    --metrics blocker_violations critical_violations coverage test_success_density
    --components https://ow2-utils.ow2.org/cmr/sonar2scava-project-mapping-ow2.json;