### PR TITLE
Replace elastic containers with the ones maintained by Bitergia

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ You should follow the following steps to run this setup:
 1. Configure the Environment variable `API_GATEWAY_VAR` under the `web-admin` service with the http://<your_hostname>:<gateway_api_public_port>
 1. (Re)Build the docker images using: `docker-compose -f docker-compose-build.yml build --no-cache --parallel`
 1. Run the crossminer plaftorm using: `docker-compose -f docker-compose-build.yml up`. Please notice that for this setup we are using an empty mongodb database for oss-db
+1. Before going on you have to setup up the credentials for the Elasticsearch database. First change the credentials used by the Kibana component and execute the command: `cd elasticsearch-sg && ./add_user.sh kibana thekibanauser thekibanapassword`. The previous command will reload the Elasticsearch credentials plugin. You can use the same script to add admin users or regular Kibana users by changing the first parameter. For more info have a look at the usage of the `add_user.sh` command.
 1. Access to the administration web app by using the following address in the web browser: http://admin-webapp/
 
 For this address to work the first step is mandatory. We need it in order for the oss-app to know the address of the admin-webapp. If instead we use something like ‘localhost’, the oss-app will also use this hostname and the information will not reach the administration webbapp.

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -136,7 +136,7 @@ services:
             - "8085:8085"
 
     elasticsearch:
-        image: acsdocker/elasticsearch:6.3.1-secured
+        image: bitergia/elasticsearch:6.1.0-secured
         command: /elasticsearch/bin/elasticsearch -E network.bind_host=0.0.0.0 -Ehttp.max_content_length=500mb
         networks:
             - default
@@ -149,17 +149,21 @@ services:
           - ES_TMPDIR=/tmp
 
     kibiter:
-      image: acsdocker/grimoirelab-kibiter:crossminer-6.3.1
-      networks:
+        image: bitergia/kibiter:secured-v6.1.4-4
+        networks:
           - default
-      depends_on:
+        depends_on:
           - elasticsearch
-      expose:
+        expose:
           - 5601
-      ports:
-       - "80:5601"
-      environment:
-      - ELASTICSEARCH_URL=https://elasticsearch:9200
+        ports:
+          - "80:5601"
+        environment:
+          - ELASTICSEARCH_URL=https://elasticsearch:9200
+          - PROJECT_NAME=CROSSMINER
+          - SUPPORT_ADDRESS=support@bitergia.com
+          - ELASTICSEARCH_USER=kibanaserver
+          - ELASTICSEARCH_PASSWORD=changeme
 
     dashb-importer:
         build: ./dashboard

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -144,6 +144,9 @@ services:
             - 9200
         ports:
           - "9200:9200"
+        volumes:
+          - /elasticsearch-index/:/elasticsearch/data
+          - ./elasticsearch-sg/sgconfig:/elasticsearch/plugins/search-guard-6/sgconfig
         environment:
           - ES_JAVA_OPTS=-Xms2g -Xmx2g
           - ES_TMPDIR=/tmp

--- a/elasticsearch-sg/add_user.sh
+++ b/elasticsearch-sg/add_user.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+#
+# Add users with roles to the sg_internal_users.yml
+
+VER_ES_PLUGIN="6.1.0-21.0"
+ES_PATH="/elasticsearch"
+FILE="sgconfig/sg_internal_users.yml"
+
+ROLE=$1
+USER=$2
+PASS=$3
+
+main(){
+  exit_if_duplicated
+
+  ES_CONTAINER=`docker-compose -f ../docker-compose-build.yml ps|grep "elasticsearch_"|grep "Up"|awk -F' ' {'print $1'}`
+  if [ -z $ES_CONTAINER ]; then
+      err "Elasticsearch is not running :_O"
+      exit 1
+  fi
+
+  hash=$(password_to_hash)
+
+  SUFFIX=`date '+%Y-%m-%d_%H%M%S'`
+  echo "cp $FILE sgconfig/sg_internal_users.yml.$SUFFIX"|sh
+
+  add_user_with_hash $FILE $USER $hash
+
+  if [ "$ROLE" == "admin" ]; then
+    append_admin_role $FILE
+  elif [ "$ROLE" == "user" ]; then
+    append_user_role $FILE
+  fi
+
+  printf "\n>>> File generated at sgconfig/sg_internal_users.yml adding the user $USER\n\n"
+
+  reload_search_guard
+}
+
+#######################################
+# Exits if the user already exists
+# Globals:
+#   FILE
+#   USER
+# Arguments:
+#   None
+# Returns:
+#   None
+#######################################
+exit_if_duplicated(){
+  echo "grep $USER: $FILE > /dev/null"|sh
+  if [ $? -eq 0 ]; then
+    err "The user $USER already exists in the file $FILE. Please remove it manually before excuting the script"
+    exit 1
+  fi
+}
+
+#######################################
+# Converts password into a hash using a Search Guard script in the container
+# Globals:
+#   ES_CONTAINER
+#   ES_PATH
+#   USER
+#   PASS
+# Arguments:
+#   None
+# Returns:
+#   myhash
+#######################################
+password_to_hash(){
+  echo "docker exec $ES_CONTAINER chmod +x $ES_PATH/plugins/search-guard-6/tools/hash.sh"|sh
+  local myhash=`echo docker exec $ES_CONTAINER $ES_PATH/plugins/search-guard-6/tools/hash.sh -p $PASS|sh`
+
+  if [ -z $myhash ]; then
+      err "Something went wrong getting the has for the user $USER"
+      exit 1
+  fi
+
+  echo "$myhash"
+}
+
+#######################################
+# Append configuration snippet to file with the role needed to have an
+#  admin user
+# Arguments:
+#   File name
+# Returns:
+#   None
+#######################################
+append_admin_role(){
+cat <<EOT >> $1
+  roles:
+    - admin
+EOT
+}
+
+#######################################
+# Append configuration snippet to file with the roles needed to have a logged
+#  kibana user
+# Arguments:
+#   File name
+# Returns:
+#   None
+#######################################
+append_user_role(){
+cat <<EOT >> $1
+  roles:
+    - kibanauser
+    - readall
+EOT
+}
+
+#######################################
+# Append configuration snippet to file with the user and hash
+# Arguments:
+#   File name
+# Returns:
+#   None
+#######################################
+add_user_with_hash() {
+cat <<EOT >> $1
+$2:
+  hash: $3
+EOT
+}
+
+err() {
+  echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $@" >&2
+}
+
+#######################################
+# Reload Search Guard configuration files by invoking a script inside the container
+# Globals:
+#   ES_CONTAINER
+#   ES_PATH
+# Arguments:
+#   None
+# Returns:
+#   None
+#######################################
+reload_search_guard(){
+  docker exec $ES_CONTAINER $ES_PATH/plugins/search-guard-6/tools/sgadmin.sh -cd $ES_PATH/plugins/search-guard-6/sgconfig -icl -nhnv -cacert $ES_PATH/config/root-ca.pem -cert $ES_PATH/config/kirk.pem -key $ES_PATH/config/kirk-key.pem
+  if [ $? -eq 0 ]; then
+    printf "\n>>> Search Guard permissions updated\n"
+    printf "\n>>> Backup copy can be found at sgconfig/sg_internal_users.yml.$SUFFIX\n"
+  else
+    err "Search Guard permissions were not updated"
+  fi
+}
+
+
+if [ $# -ne 3 ]
+  then
+    echo -e "Wrong arguments buddy..\n"
+    echo -e "Usage: add_user.sh role user password\n"
+    echo "arguments:"
+    echo -e "  role\t\tdepending on the role to be created it can be: admin|user|kibana"
+    echo -e "  user\t\tuser name"
+    echo -e "  password\tplain text password to be encrypted"
+    exit 0
+fi
+
+main

--- a/elasticsearch-sg/sgconfig/sg_action_groups.yml
+++ b/elasticsearch-sg/sgconfig/sg_action_groups.yml
@@ -1,0 +1,136 @@
+UNLIMITED:
+  readonly: true
+  permissions:
+    - "*"
+
+###### INDEX LEVEL ######
+
+INDICES_ALL:
+  readonly: true
+  permissions:
+    - "indices:*"
+
+# for backward compatibility
+ALL:
+  readonly: true
+  permissions:
+    - INDICES_ALL
+
+MANAGE:
+  readonly: true
+  permissions:
+    - "indices:monitor/*"
+    - "indices:admin/*"
+
+CREATE_INDEX:
+  readonly: true
+  permissions:
+    - "indices:admin/create"
+    - "indices:admin/mapping/put"
+
+MANAGE_ALIASES:
+  readonly: true
+  permissions:
+    - "indices:admin/aliases*"
+
+# for backward compatibility
+MONITOR:
+  readonly: true
+  permissions:
+    - INDICES_MONITOR
+
+INDICES_MONITOR:
+  readonly: true
+  permissions:
+    - "indices:monitor/*"
+
+DATA_ACCESS:
+  readonly: true
+  permissions:
+    - "indices:data/*"
+    - CRUD
+
+WRITE:
+  readonly: true
+  permissions:
+    - "indices:data/write*"
+    - "indices:admin/mapping/put"
+
+READ:
+  readonly: true
+  permissions:
+    - "indices:data/read*"
+    - "indices:admin/mappings/fields/get*"
+
+DELETE:
+  readonly: true
+  permissions:
+    - "indices:data/write/delete*"
+
+CRUD:
+  readonly: true
+  permissions:
+    - READ
+    - WRITE
+
+SEARCH:
+  readonly: true
+  permissions:
+    - "indices:data/read/search*"
+    - "indices:data/read/msearch*"
+    - SUGGEST
+
+SUGGEST:
+  readonly: true
+  permissions:
+    - "indices:data/read/suggest*"
+
+INDEX:
+  readonly: true
+  permissions:
+    - "indices:data/write/index*"
+    - "indices:data/write/update*"
+    - "indices:admin/mapping/put"
+    - "indices:data/write/bulk*"
+
+GET:
+  readonly: true
+  permissions:
+    - "indices:data/read/get*"
+    - "indices:data/read/mget*"
+
+###### CLUSTER LEVEL ######
+
+CLUSTER_ALL:
+  readonly: true
+  permissions:
+    - "cluster:*"
+
+CLUSTER_MONITOR:
+  readonly: true
+  permissions:
+    - "cluster:monitor/*"
+
+CLUSTER_COMPOSITE_OPS_RO:
+  readonly: true
+  permissions:
+    - "indices:data/read/mget"
+    - "indices:data/read/msearch"
+    - "indices:data/read/mtv"
+    - "indices:data/read/coordinate-msearch*"
+    - "indices:admin/aliases/exists*"
+    - "indices:admin/aliases/get*"
+    - "indices:data/read/scroll"
+
+CLUSTER_COMPOSITE_OPS:
+  readonly: true
+  permissions:
+    - "indices:data/write/bulk"
+    - "indices:admin/aliases*"
+    - CLUSTER_COMPOSITE_OPS_RO
+  
+MANAGE_SNAPSHOTS:
+  readonly: true
+  permissions:
+    - "cluster:admin/snapshot/*"
+    - "cluster:admin/repository/*"

--- a/elasticsearch-sg/sgconfig/sg_config.yml
+++ b/elasticsearch-sg/sgconfig/sg_config.yml
@@ -1,0 +1,221 @@
+# This is the main Search Guard configuration file where authentication 
+# and authorization is defined.
+# 
+# You need to configure at least one authentication domain in the authc of this file.
+# An authentication domain is responsible for extracting the user credentials from 
+# the request and for validating them against an authentication backend like Active Directory for example. 
+#
+# If more than one authentication domain is configured the first one which succeeds wins. 
+# If all authentication domains fail then the request is unauthenticated.
+# In this case an exception is thrown and/or the HTTP status is set to 401.
+# 
+# After authentication authorization (authz) will be applied. There can be zero or more authorizers which collect
+# the roles from a given backend for the authenticated user.
+#
+# Both, authc and auth can be enabled/disabled separately for REST and TRANSPORT layer. Default is true for both.
+#        http_enabled: true
+#        transport_enabled: true
+#
+# 5.x Migration: "enabled: true/false" will also be respected currently but only to provide backward compatibility.
+#
+# For HTTP it is possible to allow anonymous authentication. If that is the case then the HTTP authenticators try to
+# find user credentials in the HTTP request. If credentials are found then the user gets regularly authenticated.
+# If none can be found the user will be authenticated as an "anonymous" user. This user has always the username "sg_anonymous"
+# and one role named "sg_anonymous_backendrole". 
+# If you enable anonymous authentication all HTTP authenticators will not challenge.
+# 
+#
+# Note: If you define more than one HTTP authenticators make sure to put non-challenging authenticators like "proxy" or "clientcert"
+# first and the challenging one last. 
+# Because it's not possible to challenge a client with two different authentication methods (for example
+# Kerberos and Basic) only one can have the challenge flag set to true. You can cope with this situation
+# by using pre-authentication, e.g. sending a HTTP Basic authentication header in the request.
+#
+# Default value of the challenge flag is true.
+# 
+#
+# HTTP
+#   basic (challenging)
+#   proxy (not challenging, needs xff)
+#   kerberos (challenging) NOT FREE FOR COMMERCIAL
+#   clientcert (not challenging, needs https)
+#   jwt (not challenging) NOT FREE FOR COMMERCIAL
+#   host (not challenging) #DEPRECATED, will be removed in a future version.
+#                           host based authentication is configurable in sg_roles_mapping
+
+# Authc
+#   internal
+#   noop
+#   ldap  NOT FREE FOR COMMERCIAL USE
+
+# Authz
+#   ldap  NOT FREE FOR COMMERCIAL USE
+#   noop
+
+searchguard:
+  dynamic:
+    # Set filtered_alias_mode to 'disallow' to forbid more than 2 filtered aliases per index
+    # Set filtered_alias_mode to 'warn' to allow more than 2 filtered aliases per index but warns about it (default)
+    # Set filtered_alias_mode to 'nowarn' to allow more than 2 filtered aliases per index silently
+    #filtered_alias_mode: warn
+    #kibana:
+      # Kibana multitenancy - NOT FREE FOR COMMERCIAL USE
+      # see https://github.com/floragunncom/search-guard-docs/blob/master/multitenancy.md
+      # To make this work you need to install https://github.com/floragunncom/search-guard-module-kibana-multitenancy/wiki
+      #multitenancy_enabled: true
+      #server_username: kibanaserver
+      #index: '.kibana'
+      #do_not_fail_on_forbidden: false
+    http:
+      anonymous_auth_enabled: false
+      xff:
+        enabled: false
+        internalProxies: '192\.168\.0\.10|192\.168\.0\.11' # regex pattern
+        #internalProxies: '.*' # trust all internal proxies, regex pattern
+        remoteIpHeader:  'x-forwarded-for'
+        proxiesHeader:   'x-forwarded-by'
+        #trustedProxies: '.*' # trust all external proxies, regex pattern
+        ###### see https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html for regex help
+        ###### more information about XFF https://en.wikipedia.org/wiki/X-Forwarded-For
+        ###### and here https://tools.ietf.org/html/rfc7239
+        ###### and https://tomcat.apache.org/tomcat-8.0-doc/config/valve.html#Remote_IP_Valve
+    authc:
+      kerberos_auth_domain: 
+        http_enabled: false
+        transport_enabled: false
+        order: 6
+        http_authenticator:
+          type: kerberos # NOT FREE FOR COMMERCIAL USE
+          challenge: true
+          config:
+            # If true a lot of kerberos/security related debugging output will be logged to standard out
+            krb_debug: false
+            # If true then the realm will be stripped from the user name
+            strip_realm_from_principal: true
+        authentication_backend:
+          type: noop
+      basic_internal_auth_domain: 
+        http_enabled: true
+        transport_enabled: true
+        order: 4
+        http_authenticator:
+          type: basic
+          challenge: true
+        authentication_backend:
+          type: intern
+      proxy_auth_domain:
+        http_enabled: false
+        transport_enabled: false
+        order: 3
+        http_authenticator:
+          type: proxy
+          challenge: false
+          config:
+            user_header: "x-proxy-user"
+            roles_header: "x-proxy-roles"
+        authentication_backend:
+          type: noop
+      jwt_auth_domain:
+        http_enabled: false
+        transport_enabled: false
+        order: 0
+        http_authenticator:
+          type: jwt
+          challenge: false
+          config:
+            signing_key: "base64 encoded HMAC key or public RSA/ECDSA pem key"
+            jwt_header: "Authorization"
+            jwt_url_parameter: null
+            roles_key: null
+            subject_key: null
+        authentication_backend:
+          type: noop
+      clientcert_auth_domain:
+        http_enabled: false
+        transport_enabled: false
+        order: 2
+        http_authenticator:
+          type: clientcert
+          config:
+            username_attribute: cn #optional, if omitted DN becomes username
+          challenge: false
+        authentication_backend:
+          type: noop
+      ldap:
+        http_enabled: false
+        transport_enabled: false
+        order: 5
+        http_authenticator:
+          type: basic
+          challenge: false
+        authentication_backend:
+          # LDAP authentication backend (authenticate users against a LDAP or Active Directory)
+          type: ldap # NOT FREE FOR COMMERCIAL USE
+          config:
+            # enable ldaps
+            enable_ssl: false
+            # enable start tls, enable_ssl should be false
+            enable_start_tls: false
+            # send client certificate
+            enable_ssl_client_auth: false
+            # verify ldap hostname
+            verify_hostnames: true
+            hosts:
+              - localhost:8389
+            bind_dn: null
+            password: null
+            userbase: 'ou=people,dc=example,dc=com'
+            # Filter to search for users (currently in the whole subtree beneath userbase)
+            # {0} is substituted with the username 
+            usersearch: '(sAMAccountName={0})'
+            # Use this attribute from the user as username (if not set then DN is used)
+            username_attribute: null
+    authz:    
+      roles_from_myldap:
+        http_enabled: false
+        transport_enabled: false
+        authorization_backend:
+          # LDAP authorization backend (gather roles from a LDAP or Active Directory, you have to configure the above LDAP authentication backend settings too)
+          type: ldap # NOT FREE FOR COMMERCIAL USE
+          config:
+            # enable ldaps
+            enable_ssl: false
+            # enable start tls, enable_ssl should be false
+            enable_start_tls: false
+            # send client certificate
+            enable_ssl_client_auth: false
+            # verify ldap hostname
+            verify_hostnames: true
+            hosts:
+              - localhost:8389
+            bind_dn: null
+            password: null
+            rolebase: 'ou=groups,dc=example,dc=com'
+            # Filter to search for roles (currently in the whole subtree beneath rolebase)
+            # {0} is substituted with the DN of the user
+            # {1} is substituted with the username 
+            # {2} is substituted with an attribute value from user's directory entry, of the authenticated user. Use userroleattribute to specify the name of the attribute            
+            rolesearch: '(member={0})'
+            # Specify the name of the attribute which value should be substituted with {2} above
+            userroleattribute: null
+            # Roles as an attribute of the user entry
+            userrolename: disabled
+            #userrolename: memberOf
+            # The attribute in a role entry containing the name of that role, Default is "name".
+            # Can also be "dn" to use the full DN as rolename.
+            rolename: cn
+            # Resolve nested roles transitive (roles which are members of other roles and so on ...)
+            resolve_nested_roles: true
+            userbase: 'ou=people,dc=example,dc=com'
+            # Filter to search for users (currently in the whole subtree beneath userbase)
+            # {0} is substituted with the username 
+            usersearch: '(uid={0})'
+            # Skip users matching a user name, a wildcard or a regex pattern
+            #skip_users: 
+            #  - 'cn=Michael Jackson,ou*people,o=TEST'
+            #  - '/\S*/'    
+      roles_from_another_ldap:
+        enabled: false
+        authorization_backend:
+          type: ldap # NOT FREE FOR COMMERCIAL USE
+          #config goes here ...

--- a/elasticsearch-sg/sgconfig/sg_roles.yml
+++ b/elasticsearch-sg/sgconfig/sg_roles.yml
@@ -1,0 +1,255 @@
+#<sg_role_name>:
+#  cluster:
+#    - '<permission>'
+#  indices:
+#    '<indexname or alias>':
+#      '<type>':  
+#        - '<permission>'
+#      _dls_: '<dls query>'
+#      _fls_:
+#        - '<field>'
+#        - '<field>'
+
+# When a user make a request to Elasticsearch then the following roles will be evaluated to see if the user has
+# permissions for the request. A request is always associated with an action and is executed against and index (or alias)
+# and a type. If a request is executed against all indices (or all types) then the asterix ('*') is needed.
+# Every role a user has will be examined if it allows the action against an index (or type). At least one role must match
+# for the request to be successful. If no role match then the request will be denied. Currently a match must happen within
+# one single role - that means that permissions can not span multiple roles. 
+
+# For <permission>, <indexname or alias> and <type> simple wildcards and regular expressions are possible. 
+# A asterix (*) will match any character sequence (or an empty sequence)
+# A question mark (?) will match any single character (but NOT empty character)
+# Example: '*my*index' will match 'my_first_index' as well as 'myindex' but not 'myindex1'
+# Example: '?kibana' will match '.kibana' but not 'kibana'
+
+# To use a full blown regex you have to pre- and apend a '/' to use regex instead of simple wildcards
+# '/<java regex>/'
+# Example: '/\S*/' will match any non whitespace characters
+
+# Important: 
+# Index, alias or type names can not contain dots (.) in the <indexname or alias> or <type> expression.
+# Reason is that we currently parse the config file into a elasticsearch settings object which cannot cope with dots in keys.
+# Workaround: Just configure something like '?kibana' instead of '.kibana' or 'my?index' instead of 'my.index'
+# This limitation will likely removed with Search Guard 6
+
+# DLS (Document level security) - NOT FREE FOR COMMERCIAL
+# http://docs.search-guard.com/v6/document-level-security
+
+# FLS (Field level security) - NOT FREE FOR COMMERCIAL
+# http://docs.search-guard.com/v6/field-level-security
+
+# Kibana multitenancy - NOT FREE FOR COMMERCIAL
+# http://docs.search-guard.com/v6/kibana-multi-tenancy
+
+# Allows everything, but no changes to searchguard configuration index
+sg_all_access:
+  readonly: true
+  cluster:
+    - UNLIMITED
+  indices:
+    '*':
+      '*':
+        - UNLIMITED
+  tenants:
+    admin_tenant: RW
+
+# Read all, but no write permissions
+sg_readall:
+  readonly: true
+  cluster:
+    - CLUSTER_COMPOSITE_OPS_RO
+  indices:
+    '*':
+      '*':
+        - READ
+
+# Read all and monitor, but no write permissions 
+sg_readall_and_monitor:
+  cluster:
+    - CLUSTER_MONITOR
+    - CLUSTER_COMPOSITE_OPS_RO
+  indices:
+    '*':
+      '*':
+        - READ
+
+# For users which use kibana, access to indices must be granted separately
+sg_kibana_user:
+  readonly: true
+  cluster:
+    - MONITOR
+    - CLUSTER_COMPOSITE_OPS_RO
+  indices:
+    '?kibana':
+      '*':
+        - MANAGE
+        - INDEX
+        - READ
+        - DELETE
+    '*':
+      '*':
+        - indices:data/read/field_caps*
+
+# For the kibana server
+sg_kibana_server:
+  readonly: true
+  cluster:
+      - CLUSTER_MONITOR
+      - CLUSTER_COMPOSITE_OPS
+      - cluster:admin/xpack/monitoring*
+      - indices:admin/template*
+  indices:
+    '?kibana':
+      '*':
+        - INDICES_ALL
+    '?reporting*':
+      '*':
+        - INDICES_ALL
+    '?monitoring*':
+      '*':
+        - INDICES_ALL
+
+# For logstash and beats
+sg_logstash:  
+  cluster:
+    - CLUSTER_MONITOR
+    - CLUSTER_COMPOSITE_OPS
+    - indices:admin/template/get
+    - indices:admin/template/put
+  indices:
+    'logstash-*':
+      '*':
+        - CRUD
+        - CREATE_INDEX
+    '*beat*':
+      '*':
+        - CRUD
+        - CREATE_INDEX
+
+# Allows adding and modifying repositories and creating and restoring snapshots
+sg_manage_snapshots:
+  cluster:
+    - MANAGE_SNAPSHOTS
+  indices:
+    '*':
+      '*':
+        - "indices:data/write/index"
+        - "indices:admin/create"
+
+# Allows each user to access own named index
+sg_own_index:
+  cluster:
+    - CLUSTER_COMPOSITE_OPS
+  indices:
+    '${user_name}':
+      '*':
+        - INDICES_ALL
+
+### X-Pack COMPATIBILITY
+sg_xp_monitoring:
+  readonly: true
+  indices:
+    '?monitor*':
+      '*':
+        - INDICES_ALL
+
+sg_xp_alerting:
+  readonly: true
+  cluster:
+    - indices:data/read/scroll
+    - cluster:admin/xpack/watcher*
+    - cluster:monitor/xpack/watcher*
+  indices:
+    '?watches*':
+      '*':
+        - INDICES_ALL
+    '?watcher-history-*':
+      '*':
+        - INDICES_ALL
+    '?triggered_watches':
+      '*':
+        - INDICES_ALL
+    '*':
+      '*':
+        - READ
+        - indices:admin/aliases/get
+
+sg_xp_machine_learning:
+  readonly: true
+  cluster:
+    - cluster:admin/persistent*
+    - cluster:internal/xpack/ml*
+    - indices:data/read/scroll*
+    - cluster:admin/xpack/ml*
+    - cluster:monitor/xpack/ml*
+  indices:
+    '*':
+      '*':
+        - READ
+        - indices:admin/get*
+    '?ml-*':
+      '*':
+        - "*"
+
+
+### LEGACY ROLES, FOR COMPATIBILITY ONLY
+### WILL BE REMOVED IN SG7, DO NOT USE ANYMORE
+
+sg_readonly_and_monitor:
+  cluster:
+    - CLUSTER_MONITOR
+    - CLUSTER_COMPOSITE_OPS_RO
+  indices:
+    '*':
+      '*':
+        - READ
+
+# Make xpack monitoring work
+sg_monitor:
+  cluster:
+    - cluster:admin/xpack/monitoring/*
+    - cluster:admin/ingest/pipeline/put       
+    - cluster:admin/ingest/pipeline/get
+    - indices:admin/template/get
+    - indices:admin/template/put
+    - CLUSTER_MONITOR
+    - CLUSTER_COMPOSITE_OPS
+  indices:
+    '?monitor*':
+      '*':
+        - INDICES_ALL
+    '?marvel*':
+      '*':
+        - INDICES_ALL
+    '?kibana*':
+      '*':
+        - READ
+    '*':
+      '*':
+        - indices:data/read/field_caps
+
+# Make xpack alerting work
+sg_alerting:
+  cluster:
+    - indices:data/read/scroll
+    - cluster:admin/xpack/watcher/watch/put
+    - cluster:admin/xpack/watcher*
+    - CLUSTER_MONITOR
+    - CLUSTER_COMPOSITE_OPS
+  indices:
+    '?kibana*':
+      '*':
+        - READ
+    '?watches*':
+      '*':
+        - INDICES_ALL
+    '?watcher-history-*':
+      '*':
+        - INDICES_ALL
+    '?triggered_watches':
+      '*':
+        - INDICES_ALL
+    '*':
+      '*':
+        - READ

--- a/elasticsearch-sg/sgconfig/sg_roles_mapping.yml
+++ b/elasticsearch-sg/sgconfig/sg_roles_mapping.yml
@@ -1,0 +1,34 @@
+# In this file users, backendroles and hosts can be mapped to Search Guard roles.
+# Permissions for Search Guard roles are configured in sg_roles.yml
+
+sg_all_access:
+  readonly: true
+  backendroles:
+    - admin
+
+sg_logstash:
+  backendroles:
+    - logstash
+    
+sg_kibana_server:
+  readonly: true
+  users:
+    - kibanaserver
+    
+sg_kibana_user:
+  backendroles:
+    - kibanauser
+
+sg_readall:
+  readonly: true
+  backendroles:
+    - readall
+
+sg_manage_snapshots:
+  readonly: true
+  backendroles:
+    - snapshotrestore
+
+sg_own_index:
+  users:
+    - '*'


### PR DESCRIPTION
Replace customized elastic containers with the ones maintained by the Bitergia team. This includes the scripts needed to set the credentials of the Elasticsearch database + Kibana. 