### PR TITLE
[dashboard] Execute dash-importer only once

### DIFF
--- a/dashboard/starter.sh
+++ b/dashboard/starter.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 FLAG=0
+
 while true; do
     ./importer-scava-metrics.sh;
 
@@ -9,5 +10,10 @@ while true; do
         curl -XPUT https://admin:admin@elasticsearch:9200/scava-metrics-done --insecure
         FLAG=1;
     fi
+
+    if [[ $NO_LOOP -eq 1 ]]; then
+      break;
+    fi
+
     sleep 300;
 done

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -176,6 +176,7 @@ services:
         environment:
             - DASHDEBUG=0
             - BULKSIZE=500
+            - NO_LOOP=0
 
     prosoul:
         build: ./quality-model


### PR DESCRIPTION
This code allows to execute the dash-importer only once, when setting the env variable `NO_LOOP` equal to 1.