### PR TITLE
Changed path of Puppeteer tool

### DIFF
--- a/metric-platform/Dockerfile
+++ b/metric-platform/Dockerfile
@@ -32,9 +32,10 @@ RUN apt-get update \
 
 
 # Download and  deploy Puppeteer
-ADD https://github.com/blueoly/CrossPuppeteer/archive/master.zip /
-RUN  unzip master.zip \
-&&  rm master.zip
+# ADD https://github.com/blueoly/CrossPuppeteer/archive/master.zip /
+RUN svn export https://github.com/crossminer/scava/branches/$BRANCH/crossPuppeteer
+# RUN  unzip master.zip \
+# &&  rm master.zip
 
 
 WORKDIR /ossmeter


### PR DESCRIPTION
Update to the Puppeteer link (from external link to SCAVA repo)